### PR TITLE
Breaking: remove redundant Result from ``absolutize_from``

### DIFF
--- a/src/absolutize.rs
+++ b/src/absolutize.rs
@@ -8,7 +8,7 @@ pub trait Absolutize {
     fn absolutize(&self) -> io::Result<Cow<Path>>;
 
     /// Get an absolute path. This works even if the path does not exist. It gets the current working directory as the second argument.
-    fn absolutize_from(&self, cwd: &Path) -> io::Result<Cow<'_, Path>>;
+    fn absolutize_from(&self, cwd: &Path) -> Cow<'_, Path>;
 
     /// Get an absolute path. This works even if the path does not exist.
     fn absolutize_virtually<P: AsRef<Path>>(&self, virtual_root: P) -> io::Result<Cow<Path>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ use path_absolutize::*;
 let p = Path::new("../path/to/123/456");
 let cwd = env::current_dir().unwrap();
 
-println!("{}", p.absolutize_from(&cwd).unwrap().to_str().unwrap());
+println!("{}", p.absolutize_from(&cwd).to_str().unwrap());
 ```
 
 ### absolutize_virtually
@@ -372,7 +372,7 @@ impl Absolutize for PathBuf {
     }
 
     #[inline]
-    fn absolutize_from(&self, cwd: &Path) -> io::Result<Cow<'_, Path>> {
+    fn absolutize_from(&self, cwd: &Path) -> Cow<'_, Path> {
         self.as_path().absolutize_from(cwd)
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,10 +11,10 @@ impl Absolutize for Path {
     fn absolutize(&self) -> io::Result<Cow<Path>> {
         let cwd = get_cwd!();
 
-        self.absolutize_from(cwd.as_ref())
+        Ok(self.absolutize_from(cwd.as_ref()))
     }
 
-    fn absolutize_from(&self, cwd: &Path) -> io::Result<Cow<'_, Path>> {
+    fn absolutize_from(&self, cwd: &Path) -> Cow<'_, Path> {
         let mut iter = self.components();
 
         let mut has_change = false;
@@ -104,12 +104,12 @@ impl Absolutize for Path {
 
                 let path_buf = PathBuf::from(path_string);
 
-                Ok(Cow::from(path_buf))
+                Cow::from(path_buf)
             } else {
-                Ok(Cow::from(self))
+                Cow::from(self)
             }
         } else {
-            Ok(Cow::from(cwd.to_owned()))
+            Cow::from(cwd.to_owned())
         }
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,10 +11,10 @@ impl Absolutize for Path {
     fn absolutize(&self) -> io::Result<Cow<Path>> {
         let cwd = get_cwd!();
 
-        self.absolutize_from(&cwd)
+        Ok(self.absolutize_from(&cwd))
     }
 
-    fn absolutize_from(&self, cwd: &Path) -> io::Result<Cow<'_, Path>> {
+    fn absolutize_from(&self, cwd: &Path) -> Cow<'_, Path> {
         let mut iter = self.components();
 
         let mut has_change = false;
@@ -164,12 +164,12 @@ impl Absolutize for Path {
 
                 let path_buf = PathBuf::from(path_string);
 
-                Ok(Cow::from(path_buf))
+                Cow::from(path_buf)
             } else {
-                Ok(Cow::from(self))
+                Cow::from(self)
             }
         } else {
-            Ok(Cow::from(cwd.to_owned()))
+            Cow::from(cwd.to_owned())
         }
     }
 


### PR DESCRIPTION
`absolutize_from` does not return any error, so its return value does not need to be wrapped in a Result. Tested on both Windows and Ubuntu.